### PR TITLE
Ensure NFS filesystem support

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -78,6 +78,9 @@
     nfs.server.enable = true;
   };
 
+  # Ensure kernel support for network filesystems used by mounts
+  boot.supportedFilesystems = [ "nfs" ];
+
   # Docker configuration
   virtualisation.docker = {
     enable = true;


### PR DESCRIPTION
## Summary
- add NFS to the supported filesystems so the kernel modules are available at boot
- prevent client NFS mounts from failing during activation when the modules are missing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddf4736efc83328a93eb3dbc9c92bf