### PR TITLE
Add Tailscale connectivity to deployment workflow

### DIFF
--- a/.github/workflows/deploy-configs.yml
+++ b/.github/workflows/deploy-configs.yml
@@ -1,0 +1,36 @@
+name: Deploy Configurations
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          hostname: gha-deploy-${{ github.run_id }}
+          targets: ${{ secrets.REMOTE_HOST }}
+
+      - name: Show Tailscale connection details
+        run: |
+          tailscale status --peers=false
+          tailscale ip -4 || true
+          tailscale ip -6 || true
+
+      - name: Deploy configuration
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.REMOTE_HOST }}
+          username: ${{ secrets.REMOTE_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            sudo nixos-rebuild switch --flake github:${{ github.repository }}#nixos

--- a/readme.md
+++ b/readme.md
@@ -44,3 +44,16 @@ This repository holds a modular NixOS configuration with a cleaned non-flake `co
 - NFS mounts are automounted with `_netdev` to ensure networking is up first; associated directories are declared via `systemd.tmpfiles`.
 - Track changes in git so upgrades and rollbacks stay simple.
 - `modules/default.nix` collects the shared modules, user config, and hardware profile so both entry points import the exact same stack.
+
+## Continuous Deployment
+
+The `deploy-configs` workflow connects the GitHub runner to the tailnet before rebuilding the remote host. It first authenticates to Tailscale with `tailscale/github-action@v2`, bringing the runner online as `gha-deploy-<run id>` and verifying connectivity to the target machine. After logging the active Tailscale routes for debugging, the workflow uses `appleboy/ssh-action` to trigger `nixos-rebuild switch` on the remote node.
+
+### Required secrets
+
+- `REMOTE_HOST` – The target machine's Tailscale IP or MagicDNS name.
+- `REMOTE_USER` – SSH username on the remote machine.
+- `SSH_PRIVATE_KEY` – Private key authorised for that user.
+- `TAILSCALE_AUTHKEY` – Ephemeral auth key (or OAuth client credentials) that allow the runner to join the tailnet.
+
+By joining the tailnet inside the workflow, the SSH deployment step can reliably reach private infrastructure over Tailscale without exposing the host publicly.


### PR DESCRIPTION
## Summary
- add a deploy-configs GitHub Actions workflow that connects to Tailscale before running the remote rebuild
- log Tailscale connection details and run the existing SSH deploy against the host's Tailscale address
- document the new Tailscale secret and tailnet-based host configuration in the Continuous Deployment section of the README

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e348f89a80833289414225b04aeea0